### PR TITLE
Change `os.mkdirs` to `os.makedirs`

### DIFF
--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -80,7 +80,7 @@ class Compose(object):
     def run(self):
         """ High-level function to execute a compose. """
         if not os.path.isdir(self.cache_path):
-            os.mkdirs(self.cache_path)
+            os.makedirs(self.cache_path)
 
         if not os.path.isdir(self.target):
             raise SystemExit('target "%s" is not a directory. Please configure an existing target directory for this compose.' % self.target)


### PR DESCRIPTION
Possibly a typo. I can't find any references to `os.mkdirs` in the Python 2 or 3 documentation.