### PR TITLE
Add SSL verification configuration for interacting with Chacra

### DIFF
--- a/rhcephcompose/artifacts.py
+++ b/rhcephcompose/artifacts.py
@@ -9,8 +9,9 @@ log = logging.getLogger('cephcomps')
 
 class PackageArtifact(object):
     """ Artifact from a Chacra build. Base class. """
-    def __init__(self, url):
+    def __init__(self, url, ssl_verify=True):
         self.url = url
+        self.ssl_verify = ssl_verify
 
     @property
     def filename(self):
@@ -26,7 +27,7 @@ class PackageArtifact(object):
             log.info('%s already in %s, skipping download' % (self.filename, cache_dir))
         else:
             log.info('Caching %s in %s' % (self.url, cache_dir))
-            r = requests.get(self.url, stream=True)
+            r = requests.get(self.url, stream=True, verify=self.ssl_verify)
             r.raise_for_status()
             with open(cache_dest, 'wb') as f:
                 for chunk in r.iter_content(1024):
@@ -37,8 +38,8 @@ class PackageArtifact(object):
 
 class SourceArtifact(PackageArtifact):
     """ Source Artifact from chacra. """
-    def __init__(self, url):
-        super(SourceArtifact, self).__init__(url=url)
+    def __init__(self, url, ssl_verify=True):
+        super(SourceArtifact, self).__init__(url=url, ssl_verify=ssl_verify)
 
 
 class BinaryArtifact(PackageArtifact):
@@ -47,8 +48,8 @@ class BinaryArtifact(PackageArtifact):
     # Regex to parse the name and version of this binary.
     name_version_re = re.compile('^([^_]+)_([^_]+)')
 
-    def __init__(self, url):
-        super(BinaryArtifact, self).__init__(url=url)
+    def __init__(self, url, ssl_verify=True):
+        super(BinaryArtifact, self).__init__(url=url, ssl_verify=ssl_verify)
 
     @property
     def name(self):

--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -36,7 +36,7 @@ class Compose(object):
         # In Pungi terminology, assume pkgset_source "chacra" (instead
         # of "koji").
         self.chacra_url = conf['chacra_url']
-        self.chacra_ssl_verify = conf['chacra_ssl_verify']
+        self.chacra_ssl_verify = conf.get('chacra_ssl_verify', True)
         # Lookaside cache location.
         # See freedesktop.org spec for XDG_CACHE_HOME
         try:

--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -36,6 +36,7 @@ class Compose(object):
         # In Pungi terminology, assume pkgset_source "chacra" (instead
         # of "koji").
         self.chacra_url = conf['chacra_url']
+        self.chacra_ssl_verify = conf['chacra_ssl_verify']
         # Lookaside cache location.
         # See freedesktop.org spec for XDG_CACHE_HOME
         try:
@@ -132,7 +133,7 @@ class Compose(object):
         # comps.xml + variants.xml.
 
         for build_id in builds:
-            build = Build(build_id)
+            build = Build(build_id, ssl_verify=self.chacra_ssl_verify)
             # Find all the (whitelisted) binaries for this build.
             build.find_artifacts_from_chacra(chacra=self.chacra_url, whitelist=comps.all_packages)
             # Assign each binary to its respective comps group(s).


### PR DESCRIPTION
Adds a `chacra_ssl_verify` configuration option to specify a path to a certificate to verify. Other acceptable values:
- `True` (default): perform the usual verification using the system's CA certificate store.
- `False`: don't perform any verification of the Chacra server's SSL certificate. Prints many warnings.