### PR TITLE
.travis.yml: remove py3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,6 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
-    - 3.4
-    - 3.5
-# kobo does not support py3: https://bugzilla.redhat.com/1328199
-matrix:
-  allow_failures:
-    - python: 3.3
-    - python: 3.4
-    - python: 3.5
 script:
   - python setup.py test
 cache: pip


### PR DESCRIPTION
kobo does not support py3: https://bugzilla.redhat.com/1328199

Running on py3 when we know it's going to fail just wastes time.