### PR TITLE
centralize logging

### DIFF
--- a/rhcephcompose/__init__.py
+++ b/rhcephcompose/__init__.py
@@ -1,3 +1,8 @@
+import logging
+
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+log = logging.getLogger('rhcephcompose')
+
 from .build import Build
 from .comps import Comps
 from .variants import Variants

--- a/rhcephcompose/artifacts.py
+++ b/rhcephcompose/artifacts.py
@@ -4,8 +4,7 @@ import re
 import requests
 from shutil import copy
 
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger('cephcomps')
+from rhcephcompose import log
 
 
 class PackageArtifact(object):

--- a/rhcephcompose/build.py
+++ b/rhcephcompose/build.py
@@ -5,9 +5,8 @@ import re
 import requests
 
 from rhcephcompose.artifacts import BinaryArtifact, SourceArtifact
+from rhcephcompose import log
 
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger('cephcomps')
 
 
 class Build(object):

--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -1,14 +1,11 @@
 import glob
 import logging
 import os
-from rhcephcompose import Build, Comps, Variants
+from rhcephcompose import Build, Comps, Variants, log
 from shutil import copy
 import subprocess
 import textwrap
 import time
-
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger('cephcomps')
 
 
 class Compose(object):

--- a/rhcephcompose/comps.py
+++ b/rhcephcompose/comps.py
@@ -1,8 +1,7 @@
 import logging
 import xml.etree.ElementTree as ET
 
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger('cephcomps')
+from rhcephcompose import log
 
 
 class CompsGroup(list):


### PR DESCRIPTION
Centralize the logger code, so that we use a shared logger across the module.

Use a custom logger format string so log output is more user-friendly and readable.

It makes flake8 unhappy to have this code in `__init__.py` before those other imports, so eventually I should re-organize this.