### PR TITLE
compose.py: fix log import

### DIFF
--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -1,6 +1,7 @@
 import glob
 import os
-from rhcephcompose import Build, Comps, Variants, log
+from rhcephcompose import Build, Comps, Variants
+from rhcephcompose.log import log
 from shutil import copy
 import subprocess
 import textwrap


### PR DESCRIPTION
Fixes the following error:

    File "rhcephcompose/compose.py", line 86, in run
      os.mkdir(self.output_dir)
    File "rhcephcompose/compose.py", line 73, in output_dir
      log.info('Using new compose dir: %s' % output_dir)
  AttributeError: 'module' object has no attribute 'info'