### PR TITLE
log.py: silence requests' INFO logging

### DIFF
--- a/rhcephcompose/log.py
+++ b/rhcephcompose/log.py
@@ -2,3 +2,7 @@ import logging
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
 log = logging.getLogger('rhcephcompose')
+
+# Silence requests' INFO-level logging.
+logging.getLogger('requests').setLevel(logging.WARNING)
+logging.getLogger('urllib3').setLevel(logging.WARNING)


### PR DESCRIPTION
Requests (or urllib3?) prints many messages like:

  INFO: Starting new HTTPS connection (1): chacra.example.com

Silence these.