### PR TITLE
.travis.yml: install pytest-flake8 in virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
     # * 'python setup.py test' uses EasyInstall, so it will not upgrade a
     #   package to a newer version if the package is already present in a
     #   virtualenv.
-  - pip install --upgrade pytest>=2.8
+  - pip install pytest-flake8
 script:
   - python setup.py test
 cache: pip


### PR DESCRIPTION
New builds in Travis are failing with this pytest-flake8 plugin, and I'm not sure of the root cause. Installing the package into the Travis virtualenv seems to fix it.