### PR TITLE
Add --insecure command line option

### DIFF
--- a/rhcephcompose/main.py
+++ b/rhcephcompose/main.py
@@ -13,10 +13,18 @@ class RHCephCompose(object):
         parser = ArgumentParser(description='Generate a compose for RHCS.')
         parser.add_argument('config_file', metavar='config',
                             help='main configuration file for this release.')
+        parser.add_argument('--insecure', action='store_const', const=True,
+                            default=False, help='skip SSL verification')
         args = parser.parse_args()
 
         conf = kobo.conf.PyConfigParser()
         conf.load_from_file(args.config_file)
+        if args.insecure:
+            conf['chacra_ssl_verify'] = False
+            import requests
+            from requests.packages.urllib3.exceptions\
+                import InsecureRequestWarning
+            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
         compose = Compose(conf)
         compose.run()


### PR DESCRIPTION
Disables SSL certificate verification when communicating with chacra.