### PR TITLE
compose: add "latest" symlink feature

### DIFF
--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -1,3 +1,4 @@
+import errno
 import glob
 import os
 from rhcephcompose import Build, Comps, Variants
@@ -113,6 +114,23 @@ class Compose(object):
             if 'file' in extra_file:
                 copy(os.path.join('extra_files', extra_file['file']),
                      self.output_dir)
+
+    def symlink_latest(self):
+        """ Create the "latest" symlink for this output_dir. """
+        latest_tmpl = 'Ceph-{product_version}-{oslabel}-{arch}-latest'
+        latest_path = os.path.join(self.target, latest_tmpl.format(
+            product_version=self.product_version,
+            oslabel='Ubuntu',
+            arch='x86_64',
+        ))
+        try:
+            os.unlink(latest_path)
+        except OSError, e:
+            if e.errno != errno.ENOENT:
+                log.error('Problem deleting "latest" symlink')
+                raise SystemExit(e)
+        os.symlink(os.path.relpath(self.output_dir, start=self.target),
+                   latest_path)
 
     def run_distro(self, distro):
         """ Execute a compose for a distro. """

--- a/rhcephcompose/tests/test_compose.py
+++ b/rhcephcompose/tests/test_compose.py
@@ -24,3 +24,11 @@ class TestCompose(object):
         compose_date = time.strftime('%Y%m%d')
         expected = 'trees/Ceph-2-Ubuntu-x86_64-%s.t.0' % compose_date
         assert c.output_dir == expected
+
+    def test_symlink_latest(self, tmpdir, monkeypatch):
+        monkeypatch.chdir(tmpdir)
+        c = Compose(self.conf)
+        os.makedirs(c.output_dir)
+        c.symlink_latest()
+        result = os.path.realpath('trees/Ceph-2-Ubuntu-x86_64-latest')
+        assert result == os.path.realpath(c.output_dir)


### PR DESCRIPTION
Write a "-latest" symlink each time we generate a new compose.