### PR TITLE
compose: call latest_symlink()

### DIFF
--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -115,6 +115,9 @@ class Compose(object):
                 copy(os.path.join('extra_files', extra_file['file']),
                      self.output_dir)
 
+        # create "latest" symlink
+        self.symlink_latest()
+
     def symlink_latest(self):
         """ Create the "latest" symlink for this output_dir. """
         latest_tmpl = 'Ceph-{product_version}-{oslabel}-{arch}-latest'


### PR DESCRIPTION
Whoops, meant to add this in ec0b7390d42e6fb9c970a65fb61a21b3aa461239, the commit that added this feature.