### PR TITLE
Add option to skip composing sources

### DIFF
--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -46,6 +46,8 @@ class Compose(object):
         self.product_version = conf['product_version']
         # Extra files to put at the root of the compose
         self.extra_files = conf['extra_files']
+        # Whether sources composition should be skipped
+        self.no_sources = conf['no_sources']
 
     @property
     def output_dir(self):
@@ -88,8 +90,9 @@ class Compose(object):
         os.mkdir(self.output_dir)
 
         # Top-level "sources" directory, parallel to our output_dir.
-        sources_dir = self.output_dir + '-sources'
-        os.mkdir(sources_dir)
+        if not self.no_sources:
+            sources_dir = self.output_dir + '-sources'
+            os.mkdir(sources_dir)
 
         # Run the steps for each distro.
         for distro in self.builds.keys():
@@ -138,9 +141,6 @@ class Compose(object):
     def run_distro(self, distro):
         """ Execute a compose for a distro. """
 
-        # Top-level "sources" directory, parallel to our output_dir.
-        sources_dir = self.output_dir + '-sources'
-
         # Read the "builds_path" text file for this distro. Create a list of
         # each line of this file.
         builds_path = self.builds[distro]
@@ -167,9 +167,12 @@ class Compose(object):
                 comps.assign_binary_to_groups(binary)
             # Download all the source artifacts for this build and put them in
             # the "sources" directory.
-            for source in build.sources:
-                source.download(cache_dir=self.cache_path,
-                                dest_dir=sources_dir)
+            if not self.no_sources:
+                # Top-level "sources" directory, parallel to our output_dir.
+                sources_dir = self.output_dir + '-sources'
+                for source in build.sources:
+                    source.download(cache_dir=self.cache_path,
+                                    dest_dir=sources_dir)
 
         variants = Variants()
         variants.parse_file(self.variants_file)

--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -47,7 +47,7 @@ class Compose(object):
         # Extra files to put at the root of the compose
         self.extra_files = conf['extra_files']
         # Whether sources composition should be skipped
-        self.no_sources = conf['no_sources']
+        self.include_sources = conf.get('include_sources', True)
 
     @property
     def output_dir(self):
@@ -90,7 +90,7 @@ class Compose(object):
         os.mkdir(self.output_dir)
 
         # Top-level "sources" directory, parallel to our output_dir.
-        if not self.no_sources:
+        if self.include_sources:
             sources_dir = self.output_dir + '-sources'
             os.mkdir(sources_dir)
 
@@ -167,7 +167,7 @@ class Compose(object):
                 comps.assign_binary_to_groups(binary)
             # Download all the source artifacts for this build and put them in
             # the "sources" directory.
-            if not self.no_sources:
+            if self.include_sources:
                 # Top-level "sources" directory, parallel to our output_dir.
                 sources_dir = self.output_dir + '-sources'
                 for source in build.sources:

--- a/rhcephcompose/main.py
+++ b/rhcephcompose/main.py
@@ -15,8 +15,6 @@ class RHCephCompose(object):
                             help='main configuration file for this release.')
         parser.add_argument('--insecure', action='store_const', const=True,
                             default=False, help='skip SSL verification')
-        parser.add_argument('--no-sources', action='store_const', const=True,
-                            default=False, help='skip sources generation')
         args = parser.parse_args()
 
         conf = kobo.conf.PyConfigParser()
@@ -27,8 +25,6 @@ class RHCephCompose(object):
             from requests.packages.urllib3.exceptions\
                 import InsecureRequestWarning
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-        if args.no_sources:
-            conf['include_sources'] = False
 
         compose = Compose(conf)
         compose.run()

--- a/rhcephcompose/main.py
+++ b/rhcephcompose/main.py
@@ -16,7 +16,7 @@ class RHCephCompose(object):
         parser.add_argument('--insecure', action='store_const', const=True,
                             default=False, help='skip SSL verification')
         parser.add_argument('--no-sources', action='store_const', const=True,
-                            default=False, help='skip sources directory generation')
+                            default=False, help='skip sources generation')
         args = parser.parse_args()
 
         conf = kobo.conf.PyConfigParser()
@@ -28,7 +28,7 @@ class RHCephCompose(object):
                 import InsecureRequestWarning
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
         if args.no_sources:
-            conf['no_sources'] = True
+            conf['include_sources'] = False
 
         compose = Compose(conf)
         compose.run()

--- a/rhcephcompose/main.py
+++ b/rhcephcompose/main.py
@@ -15,6 +15,8 @@ class RHCephCompose(object):
                             help='main configuration file for this release.')
         parser.add_argument('--insecure', action='store_const', const=True,
                             default=False, help='skip SSL verification')
+        parser.add_argument('--no-sources', action='store_const', const=True,
+                            default=False, help='skip sources directory generation')
         args = parser.parse_args()
 
         conf = kobo.conf.PyConfigParser()
@@ -25,6 +27,8 @@ class RHCephCompose(object):
             from requests.packages.urllib3.exceptions\
                 import InsecureRequestWarning
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+        if args.no_sources:
+            conf['no_sources'] = True
 
         compose = Compose(conf)
         compose.run()


### PR DESCRIPTION
For the automatic composes for QE, the sources repository is not necessary. Rather than doing the work and deleting it, this change would allow the job to skip composing it.