### PR TITLE
verify cached files' checksums

### DIFF
--- a/rhcephcompose/artifacts.py
+++ b/rhcephcompose/artifacts.py
@@ -38,8 +38,8 @@ class PackageArtifact(object):
 
 class SourceArtifact(PackageArtifact):
     """ Source Artifact from chacra. """
-    def __init__(self, url, ssl_verify=True):
-        super(SourceArtifact, self).__init__(url=url, ssl_verify=ssl_verify)
+    def __init__(self, *args, **kwargs):
+        super(SourceArtifact, self).__init__(*args, **kwargs)
 
 
 class BinaryArtifact(PackageArtifact):
@@ -48,8 +48,8 @@ class BinaryArtifact(PackageArtifact):
     # Regex to parse the name and version of this binary.
     name_version_re = re.compile('^([^_]+)_([^_]+)')
 
-    def __init__(self, url, ssl_verify=True):
-        super(BinaryArtifact, self).__init__(url=url, ssl_verify=ssl_verify)
+    def __init__(self, *args, **kwargs):
+        super(BinaryArtifact, self).__init__(*args, **kwargs)
 
     @property
     def name(self):

--- a/rhcephcompose/tests/test_artifacts.py
+++ b/rhcephcompose/tests/test_artifacts.py
@@ -5,11 +5,11 @@ class TestArtifacts(object):
 
     def test_binary(self):
         url = 'http://chacra.example.com/mypackage_1.0-1.deb'
-        b = BinaryArtifact(url=url)
+        b = BinaryArtifact(url=url, checksum=None)
         assert b.filename == 'mypackage_1.0-1.deb'
         assert b.name == 'mypackage'
 
     def test_source(self):
         url = 'http://chacra.example.com/mypackage_1.0-1.dsc'
-        b = SourceArtifact(url=url)
+        b = SourceArtifact(url=url, checksum=None)
         assert b.filename == 'mypackage_1.0-1.dsc'


### PR DESCRIPTION
Prior to this change, we would blindly trust the files in the cache were good to use without validating the cached files' contents. This could cause issues when rhcephcompose crashed and left the cache in an invalid state, or some network interruption or other disk issue caused our cache files to exist with invalid contents.

When parsing the data for each build artifact, store the artifacts' sha512 checksum values from the chacra server, and validate that the checksums match our cached files. If they do not match, exit with an error.

The purpose of this change is to make it safer to trust the download operations and cache integrity.