### PR TITLE
artifacts' cache checksum improvements

### DIFF
--- a/rhcephcompose/tests/test_artifacts.py
+++ b/rhcephcompose/tests/test_artifacts.py
@@ -3,13 +3,14 @@ from rhcephcompose.artifacts import BinaryArtifact, SourceArtifact
 
 class TestArtifacts(object):
 
+    deb_url = 'http://chacra.example.com/mypackage_1.0-1.deb'
+    dsc_url = 'http://chacra.example.com/mypackage_1.0-1.dsc'
+
     def test_binary(self):
-        url = 'http://chacra.example.com/mypackage_1.0-1.deb'
-        b = BinaryArtifact(url=url, checksum=None)
+        b = BinaryArtifact(url=self.deb_url, checksum=None)
         assert b.filename == 'mypackage_1.0-1.deb'
         assert b.name == 'mypackage'
 
     def test_source(self):
-        url = 'http://chacra.example.com/mypackage_1.0-1.dsc'
-        b = SourceArtifact(url=url, checksum=None)
+        b = SourceArtifact(url=self.dsc_url, checksum=None)
         assert b.filename == 'mypackage_1.0-1.dsc'

--- a/rhcephcompose/tests/test_artifacts.py
+++ b/rhcephcompose/tests/test_artifacts.py
@@ -14,3 +14,17 @@ class TestArtifacts(object):
     def test_source(self):
         b = SourceArtifact(url=self.dsc_url, checksum=None)
         assert b.filename == 'mypackage_1.0-1.dsc'
+
+    def test_verify_checksum(self, tmpdir):
+        cache_file = tmpdir.join('mypackage_1.0-1.deb')
+        cache_file.write_binary('testpackagecontents')
+        checksum = 'cce64bfb35285d9c5d82e0a083cafcc6afa3292b84b26f567d92ea8ccd420e57881c9218e718c73a2ce23af53ad05ab54f168cd28ee1b5ca7ca23697fa887e1e'  # NOQA
+        b = BinaryArtifact(url=self.deb_url, checksum=checksum)
+        assert b.verify_checksum(str(cache_file)) is True
+
+    def test_verify_checksum_failure(self, tmpdir):
+        cache_file = tmpdir.join('mypackage_1.0-1.deb')
+        cache_file.write_binary('testpackagecontents')
+        checksum = 'INCORRECTSHA256HASH'
+        b = BinaryArtifact(url=self.deb_url, checksum=checksum)
+        assert b.verify_checksum(str(cache_file)) is False


### PR DESCRIPTION
The first two commits in this PR improve the unit tests for the Artifacts classes to cover the `verify_checksum()` function.

The last commit optimizes repeated calls to `verify_checksum()` for large files. Prior to this PR, we would calculate the sha512 checksum of a cached file every time we used it. This was fast for small packages, but takes several seconds for large -dbg packages.

This change saves an in-memory set of cache files we've verified so the subsequent `verify_checksum()` calls are less expensive.