### PR TITLE
tests: handle old py versions

### DIFF
--- a/rhcephcompose/tests/test_artifacts.py
+++ b/rhcephcompose/tests/test_artifacts.py
@@ -17,14 +17,22 @@ class TestArtifacts(object):
 
     def test_verify_checksum(self, tmpdir):
         cache_file = tmpdir.join('mypackage_1.0-1.deb')
-        cache_file.write_binary('testpackagecontents')
+        try:
+            cache_file.write_binary('testpackagecontents')
+        except AttributeError:
+            # python-py < v1.4.24 does not support write_binary()
+            cache_file.write('testpackagecontents')
         checksum = 'cce64bfb35285d9c5d82e0a083cafcc6afa3292b84b26f567d92ea8ccd420e57881c9218e718c73a2ce23af53ad05ab54f168cd28ee1b5ca7ca23697fa887e1e'  # NOQA
         b = BinaryArtifact(url=self.deb_url, checksum=checksum)
         assert b.verify_checksum(str(cache_file)) is True
 
     def test_verify_checksum_failure(self, tmpdir):
         cache_file = tmpdir.join('mypackage_1.0-1.deb')
-        cache_file.write_binary('testpackagecontents')
+        try:
+            cache_file.write_binary('testpackagecontents')
+        except AttributeError:
+            # python-py < v1.4.24 does not support write_binary()
+            cache_file.write('testpackagecontents')
         checksum = 'INCORRECTSHA256HASH'
         b = BinaryArtifact(url=self.deb_url, checksum=checksum)
         assert b.verify_checksum(str(cache_file)) is False


### PR DESCRIPTION
The py lib added the `write_binary()` method to LocalPath instances in py v1.4.24.

RH's internal rel-eng builds of python-py for el6 are v1.4.15.

Fall back to using the simpler `write()` method in order to support these older py lib versions.

RHEL 7 ships python-py 1.4.27 in the rhel-7-server-optional-rpms repo, so we can revert this change whenever we finally drop RHEL 6 support.