### PR TITLE
DNM: debug packages in composes

### DIFF
--- a/rhcephcompose/artifacts.py
+++ b/rhcephcompose/artifacts.py
@@ -87,3 +87,15 @@ class BinaryArtifact(PackageArtifact):
         """ Return the name of a Debian build, eg "ruby-rkerberos" or "ceph".
         Corresponds to "project_name" in Chacra. """
         return self.name_version_re.match(self.filename).group(1)
+
+    @property
+    def dbg_parent(self):
+        """
+        If this is a -dbg package, return the name of the parent package.
+
+        For example, "rbd-mirror-dbg" would return "rbd-mirror".
+        If this is not a -dbg package, return None.
+        """
+        if not self.name.endswith('-dbg'):
+            return None
+        return self.name[:-4]

--- a/rhcephcompose/build.py
+++ b/rhcephcompose/build.py
@@ -65,6 +65,12 @@ class Build(object):
                     # This package is listed in comps.xml, so we care
                     # about this one. Save it in the lookaside cache.
                     self.binaries.append(b)
+                if b.dbg_parent is not None and b.dbg_parent in whitelist:
+                    log.info('"%s" parent is in whitelist, saving' % b.name)
+                    # This package is a -dbg package, and its parent is listed
+                    # in comps.xml, so we care about this one. Save it in the
+                    # lookaside cache.
+                    self.binaries.append(b)
                 else:
                     # This package is not listed in comps.xml. Skip it.
                     log.info('"%s" pkg not whitelisted, skipping' % b.name)

--- a/rhcephcompose/comps.py
+++ b/rhcephcompose/comps.py
@@ -42,3 +42,15 @@ class Comps(object):
                 msg = 'binary %s is in group %s, appending.'
                 log.info(msg % (binary.name, group.group_id))
                 group.binaries.append(binary)
+
+    def is_present(self, name):
+        """
+        Return True if this binary name is in any group.
+
+        Useful for checking if we need to handle a -dbg binary where we know
+        the parent package's name.
+        """
+        for group in self.groups.values():
+            if name in group:
+                return True
+        return False

--- a/rhcephcompose/tests/test_artifacts.py
+++ b/rhcephcompose/tests/test_artifacts.py
@@ -40,6 +40,6 @@ class TestArtifacts(object):
 
     def test_dbg(self):
         url = 'http://chacra.example.com/mypackage-dbg_1.0-1.deb'
-        b = BinaryArtifact(url=url)
+        b = BinaryArtifact(url=url, checksum=None)
         assert b.name == 'mypackage-dbg'
         assert b.dbg_parent == 'mypackage'

--- a/rhcephcompose/tests/test_artifacts.py
+++ b/rhcephcompose/tests/test_artifacts.py
@@ -10,6 +10,7 @@ class TestArtifacts(object):
         b = BinaryArtifact(url=self.deb_url, checksum=None)
         assert b.filename == 'mypackage_1.0-1.deb'
         assert b.name == 'mypackage'
+        assert b.dbg_parent is None
 
     def test_source(self):
         b = SourceArtifact(url=self.dsc_url, checksum=None)
@@ -36,3 +37,9 @@ class TestArtifacts(object):
         checksum = 'INCORRECTSHA256HASH'
         b = BinaryArtifact(url=self.deb_url, checksum=checksum)
         assert b.verify_checksum(str(cache_file)) is False
+
+    def test_dbg(self):
+        url = 'http://chacra.example.com/mypackage-dbg_1.0-1.deb'
+        b = BinaryArtifact(url=url)
+        assert b.name == 'mypackage-dbg'
+        assert b.dbg_parent == 'mypackage'


### PR DESCRIPTION
**This change needs further work and testing before we merge this.**

With this change, rhcephcompose will place all of the debug packages into a separate "-debug" directory.

A new setting `include_dbg` toggles this behavior. (We'll want to disable `include_dbg` in Jenkins CI runs in order to save time and disk space).

TODO:

- [ ] generate a deb repository with reprepro in the "-debug" directory, rather than simply dumping all the files into that location.

- [x] Fix tests so they pass

- [ ] More testing to ensure this does not cause regressions

https://bugzilla.redhat.com/1375078