### PR TITLE
build / artifacts: use re.match() rather than search()

### DIFF
--- a/rhcephcompose/artifacts.py
+++ b/rhcephcompose/artifacts.py
@@ -81,4 +81,4 @@ class BinaryArtifact(PackageArtifact):
     def name(self):
         """ Return the name of a Debian build, eg "ruby-rkerberos" or "ceph".
         Corresponds to "project_name" in Chacra. """
-        return self.name_version_re.search(self.filename).group(1)
+        return self.name_version_re.match(self.filename).group(1)

--- a/rhcephcompose/build.py
+++ b/rhcephcompose/build.py
@@ -22,13 +22,13 @@ class Build(object):
     def name(self):
         """ Return the name of a Debian build, eg "ruby-rkerberos" or "ceph".
         Corresponds to "project_name" in Chacra. """
-        return self.name_version_re.search(self.build_id).group(1)
+        return self.name_version_re.match(self.build_id).group(1)
 
     @property
     def version(self):
         """ Return version number (version+release) of a Debian build.
             Corresponds to "version" in Chacra. """
-        return self.name_version_re.search(self.build_id).group(2)
+        return self.name_version_re.match(self.build_id).group(2)
 
     def get_chacra_build_url(self, chacra_url):
         """ Return a URL to this build's artifacts in chacra. """

--- a/rhcephcompose/tests/test_build.py
+++ b/rhcephcompose/tests/test_build.py
@@ -6,5 +6,7 @@ class TestBuild(object):
     def test_constructor(self):
         b = Build('mypackage_1.0-1')
         assert b.build_id == 'mypackage_1.0-1'
+        assert b.name == 'mypackage'
+        assert b.version == '1.0-1'
         assert b.binaries == []
         assert b.sources == []


### PR DESCRIPTION
`name_version_re` is already supposed to match the beginning of the string, so use `re.match()`.

The purpose of this change is to clarify the intention of these property
methods and optimize the code.

For the `Build` class, add unit tests to verify that these properies are
correctly set.