### PR TITLE
Add support for compose types

### DIFF
--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -8,6 +8,13 @@ import subprocess
 import textwrap
 import time
 
+COMPOSE_TYPE_MAP = {
+    'production': '',
+    'nightly': '.n',
+    'test': '.t',
+    'ci': '.ci',
+}
+
 
 class Compose(object):
     """
@@ -48,6 +55,8 @@ class Compose(object):
         self.extra_files = conf['extra_files']
         # Whether sources composition should be skipped
         self.include_sources = conf.get('include_sources', True)
+        # Compose type for output directory name
+        self.compose_type = conf.get('compose_type', 'test')
 
     @property
     def output_dir(self):
@@ -60,7 +69,8 @@ class Compose(object):
         if getattr(self, '_output_directory', None):
             return self._output_directory
         compose_date = time.strftime('%Y%m%d')
-        compose_name = 'Ceph-{product_version}-{oslabel}-{arch}-{compose_date}.t.{compose_respin}'  # NOQA
+        compose_name = 'Ceph-{product_version}-{oslabel}-{arch}-{compose_date}{compose_type}.{compose_respin}'  # NOQA
+        compose_type = COMPOSE_TYPE_MAP[self.compose_type]
         compose_respin = 0
         while 1:
             output_dir = os.path.join(self.target, compose_name.format(
@@ -68,6 +78,7 @@ class Compose(object):
                 oslabel='Ubuntu',
                 compose_date=compose_date,
                 arch='x86_64',
+                compose_type=compose_type,
                 compose_respin=compose_respin
             ))
             if os.path.isdir(output_dir):

--- a/rhcephcompose/main.py
+++ b/rhcephcompose/main.py
@@ -28,8 +28,7 @@ class RHCephCompose(object):
             from requests.packages.urllib3.exceptions\
                 import InsecureRequestWarning
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-        if args.compose_type:
-            conf['compose_type'] = args.compose_type
+        conf['compose_type'] = args.compose_type
 
         compose = Compose(conf)
         compose.run()

--- a/rhcephcompose/main.py
+++ b/rhcephcompose/main.py
@@ -15,6 +15,9 @@ class RHCephCompose(object):
                             help='main configuration file for this release.')
         parser.add_argument('--insecure', action='store_const', const=True,
                             default=False, help='skip SSL verification')
+        parser.add_argument('--compose-type', metavar='TYPE', default='test',
+                            help='choose compose type to determine suffix: '
+                            'production, nightly, test, ci (default: test)')
         args = parser.parse_args()
 
         conf = kobo.conf.PyConfigParser()
@@ -25,6 +28,8 @@ class RHCephCompose(object):
             from requests.packages.urllib3.exceptions\
                 import InsecureRequestWarning
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+        if args.compose_type:
+            conf['compose_type'] = args.compose_type
 
         compose = Compose(conf)
         compose.run()

--- a/rhcephcompose/tests/test_compose.py
+++ b/rhcephcompose/tests/test_compose.py
@@ -1,5 +1,7 @@
 import os
 import time
+import pytest
+from copy import copy
 from rhcephcompose.compose import Compose
 from kobo.conf import PyConfigParser
 
@@ -18,11 +20,20 @@ class TestCompose(object):
         assert isinstance(c, Compose)
         assert c.target == 'trees'
 
-    def test_output_dir(self, tmpdir, monkeypatch):
+    @pytest.mark.parametrize('compose_type,suffix', [
+        ('production', ''),
+        ('nightly', '.n'),
+        ('test', '.t'),
+        ('ci', '.ci'),
+    ])
+    def test_output_dir(self, tmpdir, monkeypatch, compose_type, suffix):
         monkeypatch.chdir(tmpdir)
-        c = Compose(self.conf)
+        conf = copy(self.conf)
+        conf['compose_type'] = compose_type
+        c = Compose(conf)
         compose_date = time.strftime('%Y%m%d')
-        expected = 'trees/Ceph-2-Ubuntu-x86_64-%s.t.0' % compose_date
+        expected = 'trees/Ceph-2-Ubuntu-x86_64-{0}{1}.0'.format(
+            compose_date, suffix)
         assert c.output_dir == expected
 
     def test_symlink_latest(self, tmpdir, monkeypatch):


### PR DESCRIPTION
Pungi supports four distinct compose types, which affect the name of the
compose output directory. Instead of appending a `.t` suffix before the
respin suffix, now `rhcephcompose` will use the following map:

  `production` -> no suffix
  `nightly` -> `.n`
  `test` -> `.t` (default)
  `ci` -> `.ci`