### PR TITLE
tests: pass tuple to pytest.mark.parameterize

### DIFF
--- a/rhcephcompose/tests/test_compose.py
+++ b/rhcephcompose/tests/test_compose.py
@@ -20,7 +20,7 @@ class TestCompose(object):
         assert isinstance(c, Compose)
         assert c.target == 'trees'
 
-    @pytest.mark.parametrize('compose_type,suffix', [
+    @pytest.mark.parametrize(('compose_type', 'suffix'), [
         ('production', ''),
         ('nightly', '.n'),
         ('test', '.t'),


### PR DESCRIPTION
Compatibility with pytest 2.3.5. This is what RH rel-eng ships in eng-rhel-6.