### PR TITLE
artifacts: sanity-check download() directory args

### DIFF
--- a/rhcephcompose/artifacts.py
+++ b/rhcephcompose/artifacts.py
@@ -41,6 +41,11 @@ class PackageArtifact(object):
 
     def download(self, cache_dir, dest_dir=None):
         """ Download self.url to cache_dir, then copy to dest_dir. """
+        # Ensure that these args really are directories:
+        if not os.path.isdir(cache_dir):
+            os.makedirs(self.cache_dir)
+        if dest_dir is not None and not os.path.isdir(dest_dir):
+            os.makedirs(self.dest_dir)
         # Calculate the download destination in the cache_dir:
         cache_dest = os.path.join(cache_dir, self.filename)
         # Do we have a cached copy of this file, or not?


### PR DESCRIPTION
It's easy to accidentally write code that downloads artifacts to a
directory that doesn't yet exist. When that happens, download() will
quietly write the files to a *file* named by the "cache_dir" or
"dest_dir" arg, rather than writing those files into the respective
directories.

To guard against this in new code, sanity-check the directory args to
download() and ensure that they really are directories.