### PR TITLE
compose: create repository with dbg packages

### DIFF
--- a/rhcephcompose/artifacts.py
+++ b/rhcephcompose/artifacts.py
@@ -66,6 +66,10 @@ class PackageArtifact(object):
         if dest_dir is not None:
             copy(cache_dest, dest_dir)
 
+    def __repr__(self):
+        return '%s(url=%s, checksum=%s)' % (self.__class__.__name__,
+                                            self.url, self.checksum)
+
 
 class SourceArtifact(PackageArtifact):
     """ Source Artifact from chacra. """

--- a/rhcephcompose/tests/test_artifacts.py
+++ b/rhcephcompose/tests/test_artifacts.py
@@ -11,6 +11,8 @@ class TestArtifacts(object):
         assert b.filename == 'mypackage_1.0-1.deb'
         assert b.name == 'mypackage'
         assert b.dbg_parent is None
+        expected_repr = 'BinaryArtifact(url=%s, checksum=None)' % self.deb_url
+        assert repr(b) == expected_repr
 
     def test_source(self):
         b = SourceArtifact(url=self.dsc_url, checksum=None)

--- a/rhcephcompose/tests/test_compose.py
+++ b/rhcephcompose/tests/test_compose.py
@@ -43,3 +43,25 @@ class TestCompose(object):
         c.symlink_latest()
         result = os.path.realpath('trees/Ceph-2-Ubuntu-x86_64-latest')
         assert result == os.path.realpath(c.output_dir)
+
+    def test_create_repo(self, tmpdir, monkeypatch):
+        monkeypatch.chdir(tmpdir)
+        c = Compose(self.conf)
+        # TODO: use real list of binaries here
+        c.create_repo(str(tmpdir), 'xenial', [])
+        distributions_path = tmpdir.join('conf/distributions')
+        assert distributions_path.exists()
+
+        expected = '''\
+Codename: xenial
+Suite: stable
+Components: main
+Architectures: amd64 i386
+Origin: Red Hat, Inc.
+Description: Ceph distributed file system
+DebIndices: Packages Release . .gz .bz2
+DscIndices: Sources Release .gz .bz2
+Contents: .gz .bz2
+
+'''
+        assert distributions_path.read() == expected


### PR DESCRIPTION
Prior to this change, we would dump all binary files into a single directory.
    
Build a set of all dbg binaries, and then generate a proper debian repo with metadata for this set. This allows users to install the packages with apt-get.

