### PR TITLE
tests: use pytest fixtures

### DIFF
--- a/rhcephcompose/tests/conftest.py
+++ b/rhcephcompose/tests/conftest.py
@@ -1,0 +1,9 @@
+import os
+import pytest
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture
+def fixtures_dir():
+    return os.path.join(TESTS_DIR, 'fixtures')

--- a/rhcephcompose/tests/test_compose.py
+++ b/rhcephcompose/tests/test_compose.py
@@ -1,22 +1,22 @@
 import os
 import time
 import pytest
-from copy import copy
 from rhcephcompose.compose import Compose
 from kobo.conf import PyConfigParser
 
-TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
-FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
+
+@pytest.fixture
+def conf(fixtures_dir):
+    conf_file = os.path.join(fixtures_dir, 'basic.conf')
+    conf = PyConfigParser()
+    conf.load_from_file(conf_file)
+    return conf
 
 
 class TestCompose(object):
 
-    conf_file = os.path.join(FIXTURES_DIR, 'basic.conf')
-    conf = PyConfigParser()
-    conf.load_from_file(conf_file)
-
-    def test_constructor(self):
-        c = Compose(self.conf)
+    def test_constructor(self, conf):
+        c = Compose(conf)
         assert isinstance(c, Compose)
         assert c.target == 'trees'
 
@@ -26,9 +26,8 @@ class TestCompose(object):
         ('test', '.t'),
         ('ci', '.ci'),
     ])
-    def test_output_dir(self, tmpdir, monkeypatch, compose_type, suffix):
+    def test_output_dir(self, conf, tmpdir, monkeypatch, compose_type, suffix):
         monkeypatch.chdir(tmpdir)
-        conf = copy(self.conf)
         conf['compose_type'] = compose_type
         c = Compose(conf)
         compose_date = time.strftime('%Y%m%d')
@@ -36,17 +35,17 @@ class TestCompose(object):
             compose_date, suffix)
         assert c.output_dir == expected
 
-    def test_symlink_latest(self, tmpdir, monkeypatch):
+    def test_symlink_latest(self, conf, tmpdir, monkeypatch):
         monkeypatch.chdir(tmpdir)
-        c = Compose(self.conf)
+        c = Compose(conf)
         os.makedirs(c.output_dir)
         c.symlink_latest()
         result = os.path.realpath('trees/Ceph-2-Ubuntu-x86_64-latest')
         assert result == os.path.realpath(c.output_dir)
 
-    def test_create_repo(self, tmpdir, monkeypatch):
+    def test_create_repo(self, conf, tmpdir, monkeypatch):
         monkeypatch.chdir(tmpdir)
-        c = Compose(self.conf)
+        c = Compose(conf)
         # TODO: use real list of binaries here
         c.create_repo(str(tmpdir), 'xenial', [])
         distributions_path = tmpdir.join('conf/distributions')

--- a/rhcephcompose/tests/test_comps.py
+++ b/rhcephcompose/tests/test_comps.py
@@ -1,9 +1,6 @@
 import os
 from rhcephcompose.comps import Comps
 
-TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
-FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
-
 
 class TestComps(object):
 
@@ -12,9 +9,9 @@ class TestComps(object):
         assert c.all_packages == []
         assert c.groups == {}
 
-    def test_parse_basic_file(self):
+    def test_parse_basic_file(self, fixtures_dir):
         c = Comps()
-        fixture_file = os.path.join(FIXTURES_DIR, 'comps-basic.xml')
+        fixture_file = os.path.join(fixtures_dir, 'comps-basic.xml')
         c.parse_file(fixture_file)
         assert 'calamari-server' in c.all_packages
         assert 'calamari' in c.groups

--- a/rhcephcompose/tests/test_main.py
+++ b/rhcephcompose/tests/test_main.py
@@ -3,14 +3,11 @@ import sys
 from rhcephcompose import main
 from rhcephcompose.compose import Compose
 
-TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
-FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
-
 
 class TestMain(object):
 
-    def test_constructor(self, monkeypatch):
-        conf = os.path.join(FIXTURES_DIR, 'basic.conf')
+    def test_constructor(self, fixtures_dir, monkeypatch):
+        conf = os.path.join(fixtures_dir, 'basic.conf')
         monkeypatch.setattr(sys, 'argv', ['rhcephcompose', conf])
         monkeypatch.setattr(Compose, 'run', lambda x: None)
         main.RHCephCompose()

--- a/rhcephcompose/tests/test_variants.py
+++ b/rhcephcompose/tests/test_variants.py
@@ -1,9 +1,6 @@
 import os
 from rhcephcompose.variants import Variants
 
-TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
-FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
-
 
 class TestVariants(object):
 
@@ -11,9 +8,9 @@ class TestVariants(object):
         v = Variants()
         assert v == {}
 
-    def test_parse_basic_file(self):
+    def test_parse_basic_file(self, fixtures_dir):
         v = Variants()
-        fixture_file = os.path.join(FIXTURES_DIR, 'variants-basic.xml')
+        fixture_file = os.path.join(fixtures_dir, 'variants-basic.xml')
         v.parse_file(fixture_file)
         assert 'Tools' in v
         # Test that the "Tools" variant contains the "ceph-tools" comps group.


### PR DESCRIPTION
Prior to this change:

  - Every test file had its own copy-pasted `TESTS_DIR`/`FIXTURES_DIR`.

  - `TestCompose` used a value (`self.conf`) across tests.

Refactor this to use pytest fixtures instead:

  - Move `fixtures_dir` to a central pytest fixture in `conftest.py`, and reuse this across all tests that need it.

  - Make `test_compose.py`'s old `self.conf` into a pytest fixture instead.  This makes it less likely that we will accidentally mutate `self.conf` during a test and affect other tests. It also eliminates hacks in `test_output_dir()` where we had to use `copy()` when we *did* need to mutate the value for each test parameter.