### PR TITLE
fix tests for older libs in eng-rhel-6

### DIFF
--- a/rhcephcompose/tests/test_compose.py
+++ b/rhcephcompose/tests/test_compose.py
@@ -50,7 +50,7 @@ class TestCompose(object):
         # TODO: use real list of binaries here
         c.create_repo(str(tmpdir), 'xenial', [])
         distributions_path = tmpdir.join('conf/distributions')
-        assert distributions_path.exists()
+        assert distributions_path.check(file=True)
 
         expected = '''\
 Codename: xenial

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ class PyTest(TestCommand):
 
     def run_tests(self):
         import pytest
-        errno = pytest.main('rhcephcompose --flake8 ' + self.pytest_args)
+        errno = pytest.main('rhcephcompose ' + self.pytest_args)
         sys.exit(errno)
 
 setup(
@@ -82,7 +82,6 @@ setup(
     ],
     tests_require=[
         'pytest',
-        'pytest-flake8',
     ],
     cmdclass={'test': PyTest, 'release': ReleaseCommand},
 )

--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -2,9 +2,9 @@
 
 set -euv
 
-# Install old (pytest-)flake8 for py26
+# Install old eng-rhel-6 libs for py26
 if [ ${TRAVIS_PYTHON_VERSION:0:3} == 2.6 ]; then
-  pip install pytest-flake8==0.5 flake8==2.6.2
+  pip install pytest==2.3.5 py==1.4.15
 fi
 
 # https://github.com/release-engineering/kobo/issues/31
@@ -12,4 +12,7 @@ if [ ${TRAVIS_PYTHON_VERSION:0:1} == 3 ]; then
   pip install git+git://github.com/release-engineering/kobo.git@python-3-dev
 fi
 
-pip install pytest-flake8
+# We can run the flake8 tests on py27 and above
+if [ ${TRAVIS_PYTHON_VERSION:0:3} != 2.6 ]; then
+  pip install pytest-flake8
+fi

--- a/travisci/run.sh
+++ b/travisci/run.sh
@@ -2,4 +2,9 @@
 
 set -euv
 
-python setup.py test
+# We can run the flake8 tests on py27 and above
+if [ ${TRAVIS_PYTHON_VERSION:0:3} == 2.6 ]; then
+  python setup.py test
+else
+  python setup.py test -a --flake8
+fi


### PR DESCRIPTION
The first commit updates the Python 2.6 tests so that we use the same version of py/pytest libs that are available in RH's rel-eng RHEL 6 environment.

The second commit fixes the test suite to pass on the older version of py 1.4.15 that is available.