### PR TITLE
tests: better main tests

### DIFF
--- a/rhcephcompose/tests/test_main.py
+++ b/rhcephcompose/tests/test_main.py
@@ -1,6 +1,12 @@
 import os
 import sys
 from rhcephcompose import main
+import pytest
+
+
+@pytest.fixture
+def conf(fixtures_dir):
+    return os.path.join(fixtures_dir, 'basic.conf')
 
 
 class FakeCompose(object):
@@ -17,8 +23,7 @@ class ComposeRecorder(object):
 
 class TestMain(object):
 
-    def test_constructor(self, fixtures_dir, monkeypatch):
-        conf = os.path.join(fixtures_dir, 'basic.conf')
+    def test_constructor(self, conf, monkeypatch):
         monkeypatch.setattr(sys, 'argv', ['rhcephcompose', conf])
         recorder = ComposeRecorder()
         monkeypatch.setattr(main, 'Compose', recorder)

--- a/rhcephcompose/tests/test_main.py
+++ b/rhcephcompose/tests/test_main.py
@@ -41,3 +41,10 @@ class TestMain(object):
             'variants_file': 'variants-basic.xml'
         }
         assert recorder.conf == expected
+
+    def test_insecure(self, conf, monkeypatch):
+        monkeypatch.setattr(sys, 'argv', ['rhcephcompose', '--insecure', conf])
+        recorder = ComposeRecorder()
+        monkeypatch.setattr(main, 'Compose', recorder)
+        main.RHCephCompose()
+        assert recorder.conf['chacra_ssl_verify'] is False


### PR DESCRIPTION
Assert `main()`'s behavior, rather than simply testing that we don't raise.


Ensure that main's `--insecure` arg sets the `chacra_ssl_verify` config option as expected.