### PR TITLE
add release_short configuration option

### DIFF
--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -49,6 +49,8 @@ class Compose(object):
         self.cache_path = os.path.join(xdg_cache_home, 'rhcephcompose')
         # Output target directory
         self.target = conf['target']
+        # Short name, eg "RHCEPH"
+        self.release_short = conf['release_short']
         # Release version, eg "1.3"
         try:
             self.release_version = conf['release_version']
@@ -114,11 +116,12 @@ class Compose(object):
         if getattr(self, '_output_directory', None):
             return self._output_directory
         compose_date = time.strftime('%Y%m%d')
-        compose_name = 'Ceph-{release_version}-{oslabel}-{arch}-{compose_date}{compose_type}.{compose_respin}'  # NOQA
+        compose_name = '{release_short}-{release_version}-{oslabel}-{arch}-{compose_date}{compose_type}.{compose_respin}'  # NOQA
         compose_type = COMPOSE_TYPE_MAP[self.compose_type]
         compose_respin = 0
         while 1:
             output_dir = os.path.join(self.target, compose_name.format(
+                release_short=self.release_short,
                 release_version=self.release_version,
                 oslabel='Ubuntu',
                 compose_date=compose_date,
@@ -186,8 +189,9 @@ class Compose(object):
 
     def symlink_latest(self):
         """ Create the "latest" symlink for this output_dir. """
-        latest_tmpl = 'Ceph-{release_version}-{oslabel}-{arch}-latest'
-        latest_path = os.path.join(self.target, latest_tmpl.format(
+        tmpl = '{release_short}-{release_version}-{oslabel}-{arch}-latest'
+        latest_path = os.path.join(self.target, tmpl.format(
+            release_short=self.release_short,
             release_version=self.release_version,
             oslabel='Ubuntu',
             arch='x86_64',

--- a/rhcephcompose/tests/fixtures/basic.conf
+++ b/rhcephcompose/tests/fixtures/basic.conf
@@ -13,6 +13,7 @@ chacra_url = 'https://chacra.example.com/'
 
 target = 'trees'
 
+release_short = 'RHCEPH'
 release_version = '2'
 
 extra_files = [

--- a/rhcephcompose/tests/test_compose.py
+++ b/rhcephcompose/tests/test_compose.py
@@ -32,7 +32,7 @@ class TestCompose(object):
         conf['compose_type'] = compose_type
         c = Compose(conf)
         compose_date = time.strftime('%Y%m%d')
-        expected = 'trees/Ceph-2-Ubuntu-x86_64-{0}{1}.0'.format(
+        expected = 'trees/RHCEPH-2-Ubuntu-x86_64-{0}{1}.0'.format(
             compose_date, suffix)
         assert c.output_dir == expected
 
@@ -41,7 +41,7 @@ class TestCompose(object):
         c = Compose(conf)
         os.makedirs(c.output_dir)
         c.symlink_latest()
-        result = os.path.realpath('trees/Ceph-2-Ubuntu-x86_64-latest')
+        result = os.path.realpath('trees/RHCEPH-2-Ubuntu-x86_64-latest')
         assert result == os.path.realpath(c.output_dir)
 
     def test_create_repo(self, conf, tmpdir, monkeypatch):
@@ -136,3 +136,26 @@ class TestComposeReleaseVersion(object):
         conf['product_version'] = '3'
         c = Compose(conf)
         assert c.release_version == '3'
+
+
+class TestComposeReleaseShort(object):
+
+    @pytest.fixture
+    def newconf(self, conf):
+        conf['release_short'] = 'FOOPRODUCT'
+        return conf
+
+    def test_output_dir(self, newconf, tmpdir, monkeypatch):
+        monkeypatch.chdir(tmpdir)
+        c = Compose(newconf)
+        compose_date = time.strftime('%Y%m%d')
+        expected = 'trees/FOOPRODUCT-2-Ubuntu-x86_64-%s.t.0' % compose_date
+        assert c.output_dir == expected
+
+    def test_symlink_latest(self, newconf, tmpdir, monkeypatch):
+        monkeypatch.chdir(tmpdir)
+        c = Compose(newconf)
+        os.makedirs(c.output_dir)
+        c.symlink_latest()
+        result = os.path.realpath('trees/FOOPRODUCT-2-Ubuntu-x86_64-latest')
+        assert result == os.path.realpath(c.output_dir)

--- a/rhcephcompose/tests/test_main.py
+++ b/rhcephcompose/tests/test_main.py
@@ -36,6 +36,7 @@ class TestMain(object):
             'comps': {'trusty': 'comps-basic.xml'},
             'extra_files': [{'file': 'README'}, {'file': 'EULA'},
                             {'file': 'GPL'}],
+            'release_short': 'RHCEPH',
             'release_version': '2',
             'target': 'trees',
             'variants_file': 'variants-basic.xml'


### PR DESCRIPTION
This will allow us to change the product name from "Ceph" to "RHCEPH" to match what we do with Pungi.