### PR TITLE
compose: symlink latest major version

### DIFF
--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -189,10 +189,11 @@ class Compose(object):
 
     @property
     def latest_name(self):
-        tmpl = '{release_short}-{release_version}-{oslabel}-{arch}-latest'
+        tmpl = '{release_short}-{major_version}-{oslabel}-{arch}-latest'
+        major_version = self.release_version.rsplit('.', 1)[0]
         return tmpl.format(
             release_short=self.release_short,
-            release_version=self.release_version,
+            major_version=major_version,
             oslabel='Ubuntu',
             arch='x86_64',
         )

--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -187,15 +187,19 @@ class Compose(object):
         # create "latest" symlink
         self.symlink_latest()
 
-    def symlink_latest(self):
-        """ Create the "latest" symlink for this output_dir. """
+    @property
+    def latest_name(self):
         tmpl = '{release_short}-{release_version}-{oslabel}-{arch}-latest'
-        latest_path = os.path.join(self.target, tmpl.format(
+        return tmpl.format(
             release_short=self.release_short,
             release_version=self.release_version,
             oslabel='Ubuntu',
             arch='x86_64',
-        ))
+        )
+
+    def symlink_latest(self):
+        """ Create the "latest" symlink for this output_dir. """
+        latest_path = os.path.join(self.target, self.latest_name)
         try:
             os.unlink(latest_path)
         except OSError as e:

--- a/rhcephcompose/tests/fixtures/basic.conf
+++ b/rhcephcompose/tests/fixtures/basic.conf
@@ -14,7 +14,7 @@ chacra_url = 'https://chacra.example.com/'
 target = 'trees'
 
 release_short = 'RHCEPH'
-release_version = '2'
+release_version = '2.0'
 
 extra_files = [
     {'file': 'README'},

--- a/rhcephcompose/tests/test_compose.py
+++ b/rhcephcompose/tests/test_compose.py
@@ -36,6 +36,16 @@ class TestCompose(object):
             compose_date, suffix)
         assert c.output_dir == expected
 
+    @pytest.mark.parametrize(('release_version', 'expected'), [
+        ('2', 'RHCEPH-2-Ubuntu-x86_64-latest'),
+        ('2.0', 'RHCEPH-2.0-Ubuntu-x86_64-latest'),
+        ('2.0.0', 'RHCEPH-2.0.0-Ubuntu-x86_64-latest'),
+    ])
+    def test_latest_name(self, conf, release_version, expected):
+        conf['release_version'] = release_version
+        c = Compose(conf)
+        assert c.latest_name == expected
+
     def test_symlink_latest(self, conf, tmpdir, monkeypatch):
         monkeypatch.chdir(tmpdir)
         c = Compose(conf)

--- a/rhcephcompose/tests/test_compose.py
+++ b/rhcephcompose/tests/test_compose.py
@@ -32,14 +32,14 @@ class TestCompose(object):
         conf['compose_type'] = compose_type
         c = Compose(conf)
         compose_date = time.strftime('%Y%m%d')
-        expected = 'trees/RHCEPH-2-Ubuntu-x86_64-{0}{1}.0'.format(
+        expected = 'trees/RHCEPH-2.0-Ubuntu-x86_64-{0}{1}.0'.format(
             compose_date, suffix)
         assert c.output_dir == expected
 
     @pytest.mark.parametrize(('release_version', 'expected'), [
         ('2', 'RHCEPH-2-Ubuntu-x86_64-latest'),
-        ('2.0', 'RHCEPH-2.0-Ubuntu-x86_64-latest'),
-        ('2.0.0', 'RHCEPH-2.0.0-Ubuntu-x86_64-latest'),
+        ('2.0', 'RHCEPH-2-Ubuntu-x86_64-latest'),
+        ('2.0.0', 'RHCEPH-2.0-Ubuntu-x86_64-latest'),
     ])
     def test_latest_name(self, conf, release_version, expected):
         conf['release_version'] = release_version
@@ -159,7 +159,7 @@ class TestComposeReleaseShort(object):
         monkeypatch.chdir(tmpdir)
         c = Compose(newconf)
         compose_date = time.strftime('%Y%m%d')
-        expected = 'trees/FOOPRODUCT-2-Ubuntu-x86_64-%s.t.0' % compose_date
+        expected = 'trees/FOOPRODUCT-2.0-Ubuntu-x86_64-%s.t.0' % compose_date
         assert c.output_dir == expected
 
     def test_symlink_latest(self, newconf, tmpdir, monkeypatch):

--- a/rhcephcompose/tests/test_main.py
+++ b/rhcephcompose/tests/test_main.py
@@ -37,7 +37,7 @@ class TestMain(object):
             'extra_files': [{'file': 'README'}, {'file': 'EULA'},
                             {'file': 'GPL'}],
             'release_short': 'RHCEPH',
-            'release_version': '2',
+            'release_version': '2.0',
             'target': 'trees',
             'variants_file': 'variants-basic.xml'
         }


### PR DESCRIPTION
Prior to this change, `symlink_latest()` would create a "latest" symlink for the exact release version eg. "2.3".

To have a latest "2" symlink, we had to set release_version to "2". This makes it harder to distinguish configurations and especially individual compose output directories from each other.

Determine the major version number and create that "latest" compose instead.

Update our test fixtures to use the "X.Y" version convention I expect us to use going forward.