### PR TITLE
travisci: use old eng-rhel-6 requests version

### DIFF
--- a/rhcephcompose/main.py
+++ b/rhcephcompose/main.py
@@ -5,6 +5,17 @@ import kobo.conf
 from rhcephcompose.compose import Compose
 
 
+def silence_insecure_warnings():
+    """ Silence modern requests' warnings about an insecure connection. """
+    import requests
+    try:
+        from requests.packages.urllib3.exceptions\
+            import InsecureRequestWarning
+        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+    except ImportError:
+        pass
+
+
 class RHCephCompose(object):
     """ Main class for rhcephcompose CLI. """
 
@@ -24,10 +35,7 @@ class RHCephCompose(object):
         conf.load_from_file(args.config_file)
         if args.insecure:
             conf['chacra_ssl_verify'] = False
-            import requests
-            from requests.packages.urllib3.exceptions\
-                import InsecureRequestWarning
-            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+            silence_insecure_warnings()
         conf['compose_type'] = args.compose_type
 
         compose = Compose(conf)

--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -4,7 +4,7 @@ set -euv
 
 # Install old eng-rhel-6 libs for py26
 if [ ${TRAVIS_PYTHON_VERSION:0:3} == 2.6 ]; then
-  pip install pytest==2.3.5 py==1.4.15
+  pip install pytest==2.3.5 py==1.4.15 requests==2.3.0
 fi
 
 # https://github.com/release-engineering/kobo/issues/31


### PR DESCRIPTION
Red Hat's eng-rhel-6 has python-requests-2.3.0-2.el6eng. Install this in our Travis CI py26 environment so we more closely replicate rel-eng's el6 environment.