### PR TITLE
travisci: install newer py3 kobo

### DIFF
--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -7,10 +7,8 @@ if [ ${TRAVIS_PYTHON_VERSION:0:3} == 2.6 ]; then
   pip install pytest==2.3.5 py==1.4.15 requests==2.3.0
 fi
 
-# https://github.com/release-engineering/kobo/issues/31
-if [ ${TRAVIS_PYTHON_VERSION:0:1} == 3 ]; then
-  pip install git+git://github.com/release-engineering/kobo.git@python-3-dev
-fi
+# https://github.com/release-engineering/kobo/pull/48
+pip install git+git://github.com/frenzymadness/kobo.git@python3-dev
 
 # We can run the flake8 tests on py27 and above
 if [ ${TRAVIS_PYTHON_VERSION:0:3} != 2.6 ]; then


### PR DESCRIPTION
There is a new pull request in progress to add Python 3 support to Kobo.

Use that version instead of the old/stale python-3-dev branch.

Install it in the Python 2 tests as well for more coverage.