### PR TITLE
travisci: update kobo versions

### DIFF
--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -4,11 +4,8 @@ set -euv
 
 # Install old eng-rhel-6 libs for py26
 if [ ${TRAVIS_PYTHON_VERSION:0:3} == 2.6 ]; then
-  pip install pytest==2.3.5 py==1.4.15 requests==2.3.0
+  pip install pytest==2.3.5 py==1.4.15 requests==2.3.0 kobo==0.6.0
 fi
-
-# https://github.com/release-engineering/kobo/pull/48
-pip install git+git://github.com/frenzymadness/kobo.git@python3-dev
 
 # We can run the flake8 tests on py27 and above
 if [ ${TRAVIS_PYTHON_VERSION:0:3} != 2.6 ]; then


### PR DESCRIPTION
eng-rhel-6 currently has kobo 0.6.0.

Python 3 support is available as of kobo 0.7.0, so we don't need to install from Git any more.