### PR TITLE
artifacts: configurable checksums

### DIFF
--- a/rhcephcompose/artifacts.py
+++ b/rhcephcompose/artifacts.py
@@ -9,10 +9,11 @@ from rhcephcompose.log import log
 
 class PackageArtifact(object):
     """ Artifact from a Chacra build. Base class. """
-    def __init__(self, url, checksum, ssl_verify=True):
+    def __init__(self, url, checksum, ssl_verify=True, checksum_method=sha512):
         self.url = url
         self.checksum = checksum
         self.ssl_verify = ssl_verify
+        self.checksum_method = checksum_method
         self.verified_caches = set()
 
     @property
@@ -30,7 +31,7 @@ class PackageArtifact(object):
         """
         if cache_file in self.verified_caches:
             return True
-        chsum = sha512()
+        chsum = self.checksum_method()
         with open(cache_file, 'rb') as f:
             for chunk in iter(lambda: f.read(4096), b''):
                 chsum.update(chunk)
@@ -61,7 +62,7 @@ class PackageArtifact(object):
                     f.write(chunk)
         # Sanity-check this cached file's checksum.
         if not self.verify_checksum(cache_dest):
-            raise RuntimeError('%s: sha512sum is not %s' %
+            raise RuntimeError('%s: checksum is not %s' %
                                (cache_dest, self.checksum))
         if dest_dir is not None:
             copy(cache_dest, dest_dir)

--- a/rhcephcompose/tests/test_artifacts.py
+++ b/rhcephcompose/tests/test_artifacts.py
@@ -1,3 +1,4 @@
+from hashlib import md5
 from rhcephcompose.artifacts import BinaryArtifact, SourceArtifact
 
 
@@ -27,6 +28,18 @@ class TestArtifacts(object):
             cache_file.write('testpackagecontents')
         checksum = 'cce64bfb35285d9c5d82e0a083cafcc6afa3292b84b26f567d92ea8ccd420e57881c9218e718c73a2ce23af53ad05ab54f168cd28ee1b5ca7ca23697fa887e1e'  # NOQA
         b = BinaryArtifact(url=self.deb_url, checksum=checksum)
+        assert b.verify_checksum(str(cache_file)) is True
+
+    def test_verify_checksum_md5(self, tmpdir):
+        cache_file = tmpdir.join('mypackage_1.0-1.deb')
+        try:
+            cache_file.write_binary(b'testpackagecontents')
+        except AttributeError:
+            # python-py < v1.4.24 does not support write_binary()
+            cache_file.write('testpackagecontents')
+        checksum = 'e04a72f793a87ba9e1b48000044a5e2b'
+        b = BinaryArtifact(url=self.deb_url, checksum=checksum,
+                           checksum_method=md5)
         assert b.verify_checksum(str(cache_file)) is True
 
     def test_verify_checksum_failure(self, tmpdir):


### PR DESCRIPTION
Koji currently only supports md5 for checksums. Add a checksum_method
kwarg to the artifacts classes so we can use md5 to validate build
files.