### PR TITLE
artifacts: fix cache_dir creation

### DIFF
--- a/rhcephcompose/artifacts.py
+++ b/rhcephcompose/artifacts.py
@@ -44,7 +44,7 @@ class PackageArtifact(object):
         """ Download self.url to cache_dir, then copy to dest_dir. """
         # Ensure that these args really are directories:
         if not os.path.isdir(cache_dir):
-            os.makedirs(self.cache_dir)
+            os.makedirs(cache_dir)
         if dest_dir is not None and not os.path.isdir(dest_dir):
             os.makedirs(self.dest_dir)
         # Calculate the download destination in the cache_dir:


### PR DESCRIPTION
Prior to this change, when we called `download(cache_dir)`, we failed to dynamically create the cache directory if it did not already exist. We were calling `makedirs()` on a non-existant artifact object attribute, not the method argument.

The reason we did not hit this code path in rhcephcompose until now is that we have already called `makedirs` in the main `Compose` class, before we get to the individual `PackageArtifact` classes.

In fact, this error appears to be a bad copy-and-paste from the `Compose` class.