### PR TITLE
add rhcephcompose.gather module

### DIFF
--- a/rhcephcompose/gather/__init__.py
+++ b/rhcephcompose/gather/__init__.py
@@ -1,0 +1,18 @@
+import requests
+
+
+def cache(builds, cache_dir, ssl_verify=True):
+    """
+    Download all the builds' artifacts into our cache directory.
+
+    :param set builds: set of Build objects
+    :param str cache_dir: path to a destination directory
+    :param ssl_verify: verify HTTPS connection or not (default: True)
+    """
+    session = requests.Session()
+    session.verify = ssl_verify
+    for build in builds:
+        for binary in build.binaries:
+            binary.download(cache_dir, session=session)
+        for source in build.sources:
+            source.download(cache_dir, session=session)

--- a/rhcephcompose/gather/chacra.py
+++ b/rhcephcompose/gather/chacra.py
@@ -1,0 +1,25 @@
+from rhcephcompose import Build
+from rhcephcompose.log import log
+
+
+def query(builds_file, chacra_url, whitelist, ssl_verify):
+    """
+    Find all the artifacts we will need from a given build list text file.
+
+    :param builds_file: "builds" text file for a distro.
+    :param chacra_url: chacra server to query
+    :param whitelist: whitelist of deb package names to save
+    :param ssl_verify: verify HTTPS connection or not
+    :returns: list of rhcephcompose Build objects
+    """
+    build_ids = [line.rstrip('\n') for line in open(builds_file)]
+
+    log.info('Found %d build ids in "%s"' % (len(build_ids), builds_file))
+
+    builds = []
+    for build_id in build_ids:
+        build = Build(build_id, ssl_verify=ssl_verify)
+        build.find_artifacts_from_chacra(chacra=chacra_url,
+                                         whitelist=whitelist)
+        builds.append(build)
+    return builds


### PR DESCRIPTION
Move "gather" logic out of the main Compose class and into a separate module.

This moves the "find and download" bits out of the main loops so we can eventually have more flexibility around how we add builds. It also adds flexibility for alternate gather methods (ie. Koji).