### PR TITLE
setup.py: fix two flake8 warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ class PyTest(TestCommand):
         errno = pytest.main('rhcephcompose ' + self.pytest_args)
         sys.exit(errno)
 
+
 setup(
     name='rhcephcompose',
     description='Distribution compose tool',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ readme = os.path.join(os.path.dirname(__file__), 'README.rst')
 LONG_DESCRIPTION = open(readme).read()
 
 module_file = open('rhcephcompose/__init__.py').read()
-metadata = dict(re.findall("__([a-z]+)__\s*=\s*'([^']+)'", module_file))
+metadata = dict(re.findall(r"__([a-z]+)__\s*=\s*'([^']+)'", module_file))
 version = metadata['version']
 
 


### PR DESCRIPTION
Add whitespace after class definition

Use raw string for regex