### PR TITLE
implicitly close build list file handles

### DIFF
--- a/rhcephcompose/compose.py
+++ b/rhcephcompose/compose.py
@@ -98,7 +98,8 @@ class Compose(object):
             if not os.access(filename, os.R_OK):
                 raise RuntimeError('Unreadable builds file %s' % filename)
             # Sanity-check the build NVRs for any mention of other_distros.
-            build_ids = [line.rstrip('\n') for line in open(filename)]
+            with open(filename, 'r') as builds_fh:
+                build_ids = [line.rstrip('\n') for line in builds_fh]
             other_distros = [d for d in distros if d != distro]
             for build_id in build_ids:
                 for bad_distro in other_distros:

--- a/rhcephcompose/gather/chacra.py
+++ b/rhcephcompose/gather/chacra.py
@@ -12,7 +12,8 @@ def query(builds_file, chacra_url, whitelist, ssl_verify):
     :param ssl_verify: verify HTTPS connection or not
     :returns: list of rhcephcompose Build objects
     """
-    build_ids = [line.rstrip('\n') for line in open(builds_file)]
+    with open(builds_file, 'r') as builds_fh:
+        build_ids = [line.rstrip('\n') for line in builds_fh]
 
     log.info('Found %d build ids in "%s"' % (len(build_ids), builds_file))
 

--- a/rhcephcompose/gather/chacra.py
+++ b/rhcephcompose/gather/chacra.py
@@ -21,5 +21,7 @@ def query(builds_file, chacra_url, whitelist, ssl_verify):
         build = Build(build_id, ssl_verify=ssl_verify)
         build.find_artifacts_from_chacra(chacra=chacra_url,
                                          whitelist=whitelist)
+        if not build.binaries:
+            raise RuntimeError('no binaries whitelisted for %s' % build_id)
         builds.append(build)
     return builds


### PR DESCRIPTION
CPython closes this immediately, but there's nothing in the Python language
definition that says that the filehandle must be closed/garbage-collected.
Might as well close it here using the "with" statement.