### PR TITLE
add koji support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,8 @@ script:
 after_success:
   - coveralls
 cache: pip
+addons:
+  apt:
+    packages:
+    - rpm
+    - librpm-dev

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,10 @@ shipping the RH Ceph Enterprise product for Ubuntu.
 
 See Also
 --------
-* ``rhcephcompose`` interacts with a `Chacra
-  <https://github.com/ceph/chacra>`_ instance. It queries Chacra's
-  API for build information and downloads build artifacts stored in Chacra.
-  (This is a bit similar to the way Pungi interacts with Koji.)
+* ``rhcephcompose`` interacts with `Koji instance <https://pagure.io/koji>`_
+  or a `Chacra <https://github.com/ceph/chacra>`_ instance. It queries Koji's
+  API or Chacra's API for build information and downloads build artifacts
+  stored there. (This is a bit similar to the way Pungi interacts with Koji.)
 
 * After creating a compose, you may wish to GPG-sign it with `Merfi
   <https://pypi.python.org/pypi/merfi>`_.
@@ -39,22 +39,14 @@ In the RHEL world, el6 and el7 repositories are typically separated into two
 entirely different trees in the filesystem. In Debian, a repository can mix
 several distribution versions together.
 
-Chacra has an API for ``distro_version``. Since we combine both Trusty and
-Xenial for some packages, this introduces complexity. So I store all binaries
-in "distro_version" of "all", and then use the XML and builds to determine what
-should be tagged with what.
-
-In a Brew world, we would be able to tag one build with multiple -candidate
-tags, but in Chacra there is only a one-to-one relationship between builds and
-distro_versions. So with Brew, we'd be able to tag "ceph-deploy-1.2.3" as both
-"ceph-1.3-trusty-candidate" and "ceph-1.3-xenial-candidate", but in Chacra I
-can't easily do that for individual builds.
+Using Koji, we can tag one build with multiple -candidate tags. In other
+words, we can tag "ceph-ansible-3.2.0-2redhat1" as both
+"ceph-3.2-xenial-candidate" and "ceph-3.2-bionic-candidate".
 
 In dist-git for Ubuntu, I store the branches as "-ubuntu" in order to combine
 the codebase for "-trusty" and "-xenial". The reason for this is that I always
 ended up keeping "ceph-1.2-rhel-6" and "ceph-1.2-rhel-7" identical, and it was
-a pain to do that manually. As described above, I also keep all the builds
-"combined" within Chacra.
+a pain to do that manually.
 
 Caching
 -------

--- a/rhcephcompose/common_koji.py
+++ b/rhcephcompose/common_koji.py
@@ -1,0 +1,37 @@
+try:
+    import koji
+    from koji_cli.lib import activate_session
+    HAS_KOJI = True
+except ImportError:
+    HAS_KOJI = False
+
+
+def get_session(profile):
+    """
+    Return an anonymous koji session for this profile name.
+
+    :param str profile: profile name, like "koji" or "cbs"
+    :returns: anonymous koji.ClientSession
+    """
+    # Note: this raises koji.ConfigurationError if we could not find this
+    # profile name.
+    # (ie. "check /etc/koji.conf.d/*.conf")
+    conf = koji.read_config(profile)
+    conf['authtype'] = 'noauth'
+    hub = conf['server']
+    session = koji.ClientSession(hub, {})
+    activate_session(session, conf)
+    return session
+
+
+def get_koji_pathinfo(profile):
+    """
+    Return a Koji PathInfo object for our profile.
+
+    :param str profile: profile name, like "koji" or "cbs"
+    :returns: koji.PathInfo
+    """
+    conf = koji.read_config(profile)
+    top = conf['topurl']  # or 'topdir' here for NFS access
+    pathinfo = koji.PathInfo(topdir=top)
+    return pathinfo

--- a/rhcephcompose/gather/koji.py
+++ b/rhcephcompose/gather/koji.py
@@ -1,0 +1,72 @@
+from hashlib import md5
+import posixpath
+from rhcephcompose import common_koji
+from rhcephcompose.build import Build
+from rhcephcompose.artifacts import BinaryArtifact, SourceArtifact
+from rhcephcompose.log import log
+
+
+# Koji archive types that represent a Debian source package:
+SOURCE_TYPES = ('tar', 'dsc')
+
+
+def query(profile, tag, whitelist):
+    """
+    Find all the artifacts we will need from a given Koji tag.
+
+    :param profile: Koji profile name, eg "koji"
+    :param tag: Koji tag, "ceph-3.2-xenial"
+    :param whitelist: whitelist of deb package names to save
+    :returns: list of rhcephcompose Build objects
+    """
+    if not common_koji.HAS_KOJI:
+        raise RuntimeError('Please install the koji Python library')
+    # Query koji for all builds in the tag.
+    session = common_koji.get_session(profile)
+    buildinfolist = session.listTagged(tag, inherit=True, latest=True,
+                                       type='debian')
+    pathinfo = common_koji.get_koji_pathinfo(profile)
+    # Query koji for all files in all builds.
+    builds = set()
+    for buildinfo in buildinfolist:
+        build = Build(buildinfo['name'])
+        # Get the URL of the directory for this build.
+        directory = pathinfo.typedir(buildinfo, 'debian')
+        # Look up the list of files for this build.
+        files = session.listArchives(buildinfo['id'])
+        # Find all the .debs (and corresponding dbg .debs) in our whitelist.
+        for filedata in [f for f in files if f['type_name'] == 'deb']:
+            b = parse_artifact(filedata, directory)
+            if b.name in whitelist:
+                log.info('"%s" is in whitelist, saving' % b.name)
+                build.binaries.append(b)
+            if b.dbg_parent is not None and b.dbg_parent in whitelist:
+                log.info('"%s" parent is in whitelist, saving' % b.name)
+                build.binaries.append(b)
+        # If this build had no binaries in the whitelist, skip it now.
+        if not build.binaries:
+            log.warning('skipping %s, no whitelisted binaries' % build.name)
+            continue
+        # Save the sources for this build as well.
+        for filedata in [f for f in files if f['type_name'] in SOURCE_TYPES]:
+            s = parse_artifact(filedata, directory)
+            build.sources.append(s)
+        builds.add(build)
+    return builds
+
+
+def parse_artifact(filedata, directory):
+    """
+    Parse Koji's data into an rhcephcompose.artifacts class.
+
+    :param dict filedata: a single element from Koji's listArchives call
+    :param dict directory: url to the parent directory of the files
+    :returns: BinaryArtifact or SourceArtifact, or None if we could not parse
+              this artifact.
+    """
+    opts = {'checksum': filedata['checksum'], 'checksum_method': md5}
+    url = posixpath.join(directory, filedata['filename'])
+    if filedata['type_name'] == 'deb':
+        return BinaryArtifact(url=url, **opts)
+    if filedata['type_name'] in ('tar', 'dsc'):
+        return SourceArtifact(url=url, **opts)

--- a/rhcephcompose/gather/koji.py
+++ b/rhcephcompose/gather/koji.py
@@ -23,12 +23,12 @@ def query(profile, tag, whitelist):
         raise RuntimeError('Please install the koji Python library')
     # Query koji for all builds in the tag.
     session = common_koji.get_session(profile)
-    buildinfolist = session.listTagged(tag, inherit=True, latest=True,
-                                       type='debian')
+    buildinfos = session.listTagged(tag, inherit=True, latest=True,
+                                    type='debian')
     pathinfo = common_koji.get_koji_pathinfo(profile)
     # Query koji for all files in all builds.
     builds = set()
-    for buildinfo in buildinfolist:
+    for buildinfo in buildinfos:
         build = Build(buildinfo['name'])
         # Get the URL of the directory for this build.
         directory = pathinfo.typedir(buildinfo, 'debian')

--- a/rhcephcompose/gather/koji.py
+++ b/rhcephcompose/gather/koji.py
@@ -35,7 +35,9 @@ def query(profile, tag, whitelist):
         # Look up the list of files for this build.
         files = session.listArchives(buildinfo['id'])
         # Find all the .debs (and corresponding dbg .debs) in our whitelist.
-        for filedata in [f for f in files if f['type_name'] == 'deb']:
+        for filedata in files:
+            if filedata['type_name'] != 'deb':
+                continue
             b = parse_artifact(filedata, directory)
             if b.name in whitelist:
                 log.info('"%s" is in whitelist, saving' % b.name)

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
     keywords='compose, pungi',
     long_description=LONG_DESCRIPTION,
     scripts=['bin/rhcephcompose'],
+    # Koji is not a hard dependency here for Travis CI's sake
     install_requires=[
         'kobo',
         'requests',

--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -7,9 +7,11 @@ if [ ${TRAVIS_PYTHON_VERSION:0:3} == 2.6 ]; then
   pip install pytest==2.3.5 py==1.4.15 requests==2.3.0 kobo==0.6.0
 fi
 
-# We can run the flake8 tests on py27 and above
 if [ ${TRAVIS_PYTHON_VERSION:0:3} != 2.6 ]; then
+  # We can run the flake8 tests on py27 and above
   pip install pytest-flake8
+  # And the koji tests
+  pip install koji
 fi
 
 pip install pytest-cov python-coveralls


### PR DESCRIPTION
Support listing and downloading builds from Koji.

When "koji_profile" is set, rhcephcompose will use Koji as a build source instead of Chacra.