### PR TITLE
artifacts: use requests session for download

### DIFF
--- a/rhcephcompose/artifacts.py
+++ b/rhcephcompose/artifacts.py
@@ -57,7 +57,7 @@ class PackageArtifact(object):
             log.info(msg % (self.filename, cache_dir))
         else:
             log.info('Caching %s in %s' % (self.url, cache_dir))
-            r = requests.get(self.url, stream=True, verify=self.ssl_verify)
+            r = session.get(self.url, stream=True, verify=self.ssl_verify)
             r.raise_for_status()
             with open(cache_dest, 'wb') as f:
                 for chunk in r.iter_content(1024):


### PR DESCRIPTION
Prior to this change, we would throw away the persistent requests session instead of using it. This meant that even if callers passed in a persistent requests session, we would just create a new one with `requests.get()`.

This is a fix for the feature introduced in 6567a1f37d475e98bb63512a723c6fdbcaef0027