### PR TITLE
travisci: use old eng-rhel-6 PyYAML version

### DIFF
--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -4,7 +4,7 @@ set -euv
 
 # Install old eng-rhel-6 libs for py26
 if [ ${TRAVIS_PYTHON_VERSION:0:3} == 2.6 ]; then
-  pip install pytest==2.3.5 py==1.4.15 requests==2.3.0 kobo==0.6.0
+  pip install pytest==2.3.5 py==1.4.15 requests==2.3.0 kobo==0.6.0 PyYAML==3.10
 fi
 
 if [ ${TRAVIS_PYTHON_VERSION:0:3} != 2.6 ]; then


### PR DESCRIPTION
Red Hat's eng-rhel-6 has PyYAML-3.10-3.el6eng.1. Install this in our Travis CI py26 environment so we more closely replicate rel-eng's el6 environment.